### PR TITLE
Editorial fixes to the JOSS paper

### DIFF
--- a/paper.md
+++ b/paper.md
@@ -28,14 +28,15 @@ The evolution of the climate is controlled by highly complex physical dynamics.
 However, simplified representations are surprisingly powerful tools for understanding these dynamics [@held_2010_two_layer] and making climate projections [@meinshausen_2011_rcp].
 The field of simple climate modelling is widely used, in particular for assessing the climatic implications of large numbers of different emissions scenarios, a task which cannot be performed with more complex models because of computational constraints.
 
-One of the most commonly used models of the climate's response to changes in the `Earth's energy balance' (energy in compared to energy out of the earth system) is the two-layer model originally introduced by @held_2010_two_layer.
+One of the most commonly used models of the climate's response to changes in the "Earth's energy balance" 
+(energy input compared to energy output of the earth system) is the two-layer model originally introduced by @held_2010_two_layer.
 While this model must be given energy imbalances (more precisely, radiative forcing) rather than emissions, it is nonetheless a widely used tool within climate science.
 Approximately speaking, the model represents the Earth System as an ocean with two-layers.
 The upper layer absorbs excess heat in the Earth System and then exchanges heat with the deep layer.
-As a result, in response to a perturbation, the model responds with a distinctive two-timescale response, commonly referred to as the `fast' and `slow' warming components.
+As a result, in response to a perturbation, the model responds with a distinctive two-timescale response, commonly referred to as the "fast" and "slow" warming components.
 Since @held_2010_two_layer, the model has been extended to include updated representations of the efficiency of ocean heat uptake [@geoffroy_2013_two_layer2] as well as a state-dependent response to radiative forcing [@bloch_johnson_2015_feedback_dependence; @rohrschneider_2019_simple].
 
-`OpenSCM Two Layer Model' is an object-oriented, open-source implementation of the two-layer model.
+"OpenSCM Two Layer Model" is an object-oriented, open-source implementation of the two-layer model.
 It provides an extensible interface for the two-layer model, which could then be coupled with other modules as researchers see fit.
 The implementation also provides an easy way to convert between the two-layer model of @held_2010_two_layer and the mathematically equivalent two-timescale impulse response model, used most notably as the thermal core of the FaIR model [@smith_2018_fairv1_3].
 The conversion between the two is an implementation of the proof by @geoffroy_2013_two_layer1.
@@ -48,7 +49,7 @@ It was used in Phase 1 of the Reduced Complexity Model Intercomparison Project [
 The FaIR model [@fair_repo] implements a mathematically equivalent model but does not provide as clear a conversion between the two-layer model and the two-timescale response as is provided here.
 We hope that this implementation could interface with other simple climate models like FaIR to allow simpler exploration of the combined behaviour of interacting climate components with minimal coupling headaches.
 
-As implemented here, the `OpenSCM Two Layer Model' interface is intended to be used in research or education.
+As implemented here, the "OpenSCM Two Layer Model" interface is intended to be used in research or education.
 
 # Acknowledgements
 


### PR DESCRIPTION
Made a few style fixes (mostly using " instead of the LaTex style backtick quotes).

Related to openjournals/joss-reviews#2728

> I'm guessing none of these apply here but will leave it to the maintainers to decide 🙂 

- [ ] Tests added
- [ ] Documentation added
- [ ] Example added (in the documentation, to an existing notebook, or in a new notebook)
- [ ] Description in ``CHANGELOG.rst`` added (single line such as: ``(`#XX <https://github.com/openscm/openscm-twolayermodel/pull/XX>`_) Added feature which does something``)
