### PR TITLE
Fix broken ReadTheDocs links in the README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,13 +57,13 @@ dependencies using
 Documentation
 -------------
 
-Documentation can be found at our `documentation pages <https://openscm-twolayermodel.readthedocs.io/en/latest/>`_
+Documentation can be found at our `documentation pages <https://openscm-two-layer-model.readthedocs.io/en/latest/>`_
 (we are thankful to `Read the Docs <https://readthedocs.org/>`_ for hosting us).
 
 Contributing
 ------------
 
-Please see the `Development section of the docs <https://openscm-twolayermodel.readthedocs.io/en/latest/development.html>`_.
+Please see the `Development section of the docs <https://openscm-two-layer-model.readthedocs.io/en/latest/development.html>`_.
 
 .. sec-begin-links
 


### PR DESCRIPTION
The link to the main docs and the contributing guide were broken because
of missing `-` in the project name part of the URL. 

Related to openjournals/joss-reviews#2728

- [ ] Tests added
- [ ] Documentation added
- [ ] Example added (in the documentation, to an existing notebook, or in a new notebook)
- [ ] Description in ``CHANGELOG.rst`` added (single line such as: ``(`#XX <https://github.com/openscm/openscm-twolayermodel/pull/XX>`_) Added feature which does something``)
