### PR TITLE
Option to remove default progress bar

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,11 @@ The changes listed in this file are categorised as follows:
 master
 ------
 
+Changed
+~~~~~~~
+
+- (`#20 <https://github.com/openscm/openscm-twolayermodel/pull/20>`_) Option to remove tqdm progress bar by passing `progress=False`
+
 v0.2.0 - 2020-10-09
 -------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,7 +20,7 @@ master
 Changed
 ~~~~~~~
 
-- (`#20 <https://github.com/openscm/openscm-twolayermodel/pull/20>`_) Option to remove tqdm progress bar by passing `progress=False`
+- (`#20 <https://github.com/openscm/openscm-twolayermodel/pull/20>`_) Option to remove tqdm progress bar by passing ``progress=False``
 
 v0.2.0 - 2020-10-09
 -------------------

--- a/notebooks/running-scenarios.ipynb
+++ b/notebooks/running-scenarios.ipynb
@@ -289,7 +289,7 @@
     "output = []\n",
     "for a in tqdman.tqdm(a_values, desc=\"Parameter settings\"):\n",
     "    runner.a = a\n",
-    "    output.append(runner.run_scenarios(scenarios, progress=False))\n",
+    "    output.append(runner.run_scenarios(scenarios))\n",
     "\n",
     "output = run_append(output)\n",
     "output"

--- a/notebooks/running-scenarios.ipynb
+++ b/notebooks/running-scenarios.ipynb
@@ -18,8 +18,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "<ipython-input-1-c16e6c863969>:7: TqdmExperimentalWarning: Using `tqdm.autonotebook.tqdm` in notebook mode. Use `tqdm.tqdm` instead to force console mode (e.g. in jupyter console)\n",
-      "  import tqdm.autonotebook as tqdman\n"
+      "/nfs/b0110/Users/mencsm/miniconda3/envs/tlrdev/lib/python3.7/site-packages/ipykernel_launcher.py:7: TqdmExperimentalWarning: Using `tqdm.autonotebook.tqdm` in notebook mode. Use `tqdm.tqdm` instead to force console mode (e.g. in jupyter console)\n",
+      "  import sys\n"
      ]
     }
    ],
@@ -171,40 +171,12 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "52ca53d77d96419d963e0bda083f7678",
+       "model_id": "9318a5c274fd4c32986fc142b5bee69e",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
        "HBox(children=(HTML(value='Parameter settings'), FloatProgress(value=0.0, max=2.0), HTML(value='')))"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "HBox(children=(HTML(value='scenarios'), FloatProgress(value=1.0, bar_style='info', layout=Layout(width='20px')…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "HBox(children=(HTML(value='scenarios'), FloatProgress(value=1.0, bar_style='info', layout=Layout(width='20px')…"
       ]
      },
      "metadata": {},
@@ -317,7 +289,7 @@
     "output = []\n",
     "for a in tqdman.tqdm(a_values, desc=\"Parameter settings\"):\n",
     "    runner.a = a\n",
-    "    output.append(runner.run_scenarios(scenarios))\n",
+    "    output.append(runner.run_scenarios(scenarios, progress=False))\n",
     "\n",
     "output = run_append(output)\n",
     "output"
@@ -384,7 +356,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.9"
   }
  },
  "nbformat": 4,

--- a/src/openscm_twolayermodel/base.py
+++ b/src/openscm_twolayermodel/base.py
@@ -173,7 +173,7 @@ class TwoLayerVariant(Model):
         )
 
     def run_scenarios(  # pylint:disable=too-many-locals
-        self, scenarios, driver_var="Effective Radiative Forcing"
+        self, scenarios, driver_var="Effective Radiative Forcing", progress=True,
     ):
         """
         Run scenarios.
@@ -191,6 +191,9 @@ class TwoLayerVariant(Model):
 
         driver_var : str
             The variable in ``scenarios`` to use as the driver of the model
+
+        progress : bool
+            Whether to display a progress bar
 
         Returns
         -------
@@ -227,7 +230,7 @@ class TwoLayerVariant(Model):
 
         driver_ts = driver.timeseries()
         for i, (label, row) in tqdman.tqdm(
-            enumerate(driver_ts.iterrows()), desc="scenarios", leave=False
+            enumerate(driver_ts.iterrows()), desc="scenarios", leave=False, disable=not(progress)
         ):
             meta = dict(zip(driver_ts.index.names, label))
             row_no_nan = row.dropna()

--- a/src/openscm_twolayermodel/base.py
+++ b/src/openscm_twolayermodel/base.py
@@ -230,7 +230,10 @@ class TwoLayerVariant(Model):
 
         driver_ts = driver.timeseries()
         for i, (label, row) in tqdman.tqdm(
-            enumerate(driver_ts.iterrows()), desc="scenarios", leave=False, disable=not(progress)
+            enumerate(driver_ts.iterrows()),
+            desc="scenarios",
+            leave=False,
+            disable=not (progress),
         ):
             meta = dict(zip(driver_ts.index.names, label))
             row_no_nan = row.dropna()


### PR DESCRIPTION
~~Designed to run several parameter runs in one go (#19)~~

~~(Not finished yet - all I've done so far is remove the default progress bar)~~

Remove default progress bar by passing `progress=False`. Default behaviour unchanged.

- [x] Documentation added
- [x] Example added (in the documentation, to an existing notebook, or in a new notebook)
- [x] Description in ``CHANGELOG.rst`` added (single line such as: ``(`#XX <https://github.com/openscm/openscm-twolayermodel/pull/XX>`_) Added feature which does something``)
