### PR TITLE
Fix setup commands in development documentation

### DIFF
--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -43,10 +43,10 @@ To get setup as a developer, we recommend the following steps (if any of these t
     #. Change your current directory to OpenSCM Two Layer Model's root directory (i.e. the one which contains ``README.rst``), ``cd openscm-twolayermodel``
     #. Create a virtual environment to use with OpenSCM Two Layer Model ``python3 -m venv venv``
     #. Activate your virtual environment ``source ./venv/bin/activate``
-    #. Upgrade pip ``pip intall --upgrade pip``
+    #. Upgrade pip ``pip install --upgrade pip``
     #. Install the development dependencies (very important, make sure your virtual environment is active before doing this) ``pip install -e .[dev]``
 
-#. Make sure the tests pass by running ``make check``, if that fails the commands can be read out of the ``Makefile``
+#. Make sure the tests pass by running ``make checks``, if that fails the commands can be read out of the ``Makefile``
 
 
 Getting help


### PR DESCRIPTION
This fixes two commands quoted in the current documentation (and unchanged for the documentation source files against the current `master` branch) under ['Development' -> 'Getting setup'](https://openscm-two-layer-model.readthedocs.io/en/stable/development.html#getting-setup).

The fix for the command to run the tests is particularly important as I believe that is the only place in the documentation where the standard means to run the tests is stated (a docs search and a codebase `grep` all return nothing for the matching command from the Makefile, `make checks`, which seemed the only candidate for the right command).

(I believe you host your built docs on ReadtheDocs so there is no built docs hosted on GitHub to built to process this fix into.)

This is a trivial PR so I do not think it merits any of the following generic tick-box items including any changelog entry, hence the 'n/a' reply, though please let me know if you disagree:

- [n/a] Tests added
- [n/a] Documentation added
- [n/a] Example added (in the documentation, to an existing notebook, or in a new notebook)
- [n/a] Description in ``CHANGELOG.rst`` added (single line such as: ``(`#XX <https://github.com/openscm/openscm-twolayermodel/pull/XX>`_) Added feature which does something``)

[PR opened to address a minor issue noticed as part of the review towards openjournals/joss-reviews#2766.]